### PR TITLE
Remove textbox limit

### DIFF
--- a/src/pages/playground/gameplay.tsx
+++ b/src/pages/playground/gameplay.tsx
@@ -16,7 +16,7 @@ const Index = () => {
                 "Now, if you're part of Control Group Kepler-Seven, we implanted a tiny microchip about the size of a postcard into your skull. Most likely you've forgotten it's even there, but if it starts vibrating and beeping during this next test, let us know, because that means it's about to hit five hundred degrees, so we're gonna need to go ahead and get that out of you pretty fast."
               }
               disabled={false}
-              removeLimit={false}
+              removeLimit={true}
               sendKeystroke={() => false}
               isSuddenDeath={false}
             />


### PR DESCRIPTION
The limit existed previously for anti-cheat purposes, which are no longer relevant due to the engine rewrite. Custom quotes with long words cannot be typed with this limit, including valid German words.